### PR TITLE
refactor to leverage hapi plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,20 @@ npm install hapi-dummy-api
 
 ```javascript
 var Hapi = require('hapi');
-var config = require('getconfig');
-var server = new Hapi.Server('localhost', config.http.port);
-
-// require our dummy API generator
-var API = require('hapi-dummy-api');
-
+var server = new Hapi.Server('localhost', 3000);
+var dummyAPI = require('hapi-dummy-api');
 
 // all these config items are optionals
-var tempAPI = new API({
+var peopleOptions = {
     // Optionally give it some starting data (should be an array)
     // defaults to [];
-    data: [
-        {
-            id: 0,
-            name: 'mary'
-        },
-        {
-            id: 1,
-            name: 'bob'
-        }
-    ],
+    data: [{
+        id: 0,
+        name: 'mary'
+    }, {
+        id: 1,
+        name: 'bob'
+    }],
     // the root RESTful resource URL
     rootUrl: '/api/people',
     // specify which property name should be the "id"
@@ -45,27 +38,40 @@ var tempAPI = new API({
     idProperty: 'id',
     // Optionally give it a delay (in milliseconds) to simulate network latency
     // as you'd have in real clientapp situation.
-    delay: 200,
-    // hapi plugin name, defaults to 'api'
-    name: 'fake-people-api',
-    // hapi plugin version, defaults to '0.0.0',
-    version: '0.0.1'
-});
+    delay: 200
+};
 
+// here is a second resource
+var thingsOptions = {
+    data: [{
+        id: 0,
+        name: 'chair'
+    }],
+    rootUrl: '/api/things'
+};
 
-server.pack.register(fakeApi, function (err) {
-    if (err) throw err;
-    // If everything loaded correctly, start the server:
-    server.start(function (err) {
+server.pack.register(
+    // register the plugin twice with both of our configs
+    [{
+        plugin: dummyAPI,
+        options: peopleOptions
+    }, {
+        plugin: dummyAPI,
+        options: thingsOptions
+    }],
+    function (err) {
         if (err) throw err;
-        console.log("running at: http://localhost:" + config.http.port + ");
-    });
-});
+        server.start(function (err) {
+            if (err) throw err;
+            console.log("running at: http://localhost:" + 3000);
+        });
+    }
+);
 ```
 
 ## additional info
 
-There's really not much more to it, the source is < 100 lines and should be quite readable. 
+There's really not much more to it, the source is < 100 lines and should be quite readable.
 
 This is meant for development only, obviously. It would be the worlds most terrible and insecure production API. Please don't use it for that. Use it to aid development of client apps.
 

--- a/hapi-dummy-api.js
+++ b/hapi-dummy-api.js
@@ -1,96 +1,95 @@
-// Instantiate this, then register it as a hapi plugin
-// and you've got yourself a fake API for quick/easy
+// register this as a hapi plugin and pass in an options object to override
+// defaults and you've got yourself a fake API for quick/easy
 // clientside dev.
 var _ = require('underscore');
 
-
-function API(spec) {
-    this.data = spec.data || [];
-    this.root = spec.rootUrl || '/api';
-    this.idProperty = spec.idProperty || 'id';
-    this.delay = spec.delay || 0;
-    this.name = spec.name || 'api';
-    this.version = spec.version || '0.0.0';
-
-    this.idCounter = this.data.length;
-
-    // bind our register function to maintain scope
-    // since hapi doesn't do that for us
-    this.register = _.bind(this.register, this);
-}
-
-API.prototype.get = function (id) {
-    var searchObj = {};
-    searchObj[this.idProperty] = id;
-    var found = _.findWhere(this.data, searchObj);
-    if (found) return found;
-    // try it as a number
-    searchObj[this.idProperty] = Number(id);
-    return _.findWhere(this.data, searchObj)
+var defaults = {
+    data: [],
+    rootUrl: '/api',
+    idProperty: 'id',
+    delay: 0
 };
 
-API.prototype.register = function (plugin, options, next) {
-    var self = this;
+exports.register = function (plugin, options, next) {
+
+    options  = _.defaults(options, defaults);
+    var data = options.data;
+    var idCounter = data.length;
+
+    var get = function (id) {
+        var searchObj = {};
+        searchObj[options.idProperty] = id;
+        var found = _.findWhere(data, searchObj);
+        if (found) return found;
+        // try it as a number
+        searchObj[options.idProperty] = Number(id);
+        return _.findWhere(data, searchObj);
+    };
 
     plugin.route({
         method: 'GET',
-        path: self.root,
+        path: options.rootUrl,
         handler: function (request, reply) {
             _.delay(function () {
-                reply(self.data);
-            }, self.delay);
+                reply(data);
+            }, options.delay);
         }
     });
 
     plugin.route({
         method: 'POST',
-        path: self.root,
+        path: options.rootUrl,
         handler: function (request, reply) {
             var person = request.payload;
-            person.id = self.idCounter++;
-            self.data.push(person);
+            person.id = idCounter++;
+            data.push(person);
             _.delay(function () {
                 reply(person).code(201);
-            }, self.delay);
+            }, options.delay);
         }
     });
 
     plugin.route({
         method: 'GET',
-        path: self.root + '/{' + self.idProperty + '}',
+        path: options.rootUrl + '/{' + options.idProperty + '}',
         handler: function (request, reply) {
-            var found = self.get(request.params[self.idProperty]);
+            var found = get(request.params[options.idProperty]);
             _.delay(function () {
                 reply(found).code(found ? 200 : 404);
-            }, self.delay);
+            }, options.delay);
         }
     });
 
     plugin.route({
         method: 'DELETE',
-        path: self.root + '/{' + self.idProperty + '}',
+        path: options.rootUrl + '/{' + options.idProperty + '}',
         handler: function (request, reply) {
-            var found = self.get(request.params[self.idProperty]);
-            if (found) self.data = _.without(self.data, found);
+            var found = get(request.params[options.idProperty]);
+            if (found) data = _.without(data, found);
             _.delay(function () {
                 reply(found).code(found ? 200 : 404);
-            }, self.delay);
+            }, options.delay);
         }
     });
 
     plugin.route({
         method: 'PUT',
-        path: self.root + '/{' + self.idProperty + '}',
+        path: options.rootUrl + '/{' + options.idProperty + '}',
         handler: function (request, reply) {
-            var found = self.get(request.params[self.idProperty]);
+            var found = get(request.params[options.idProperty]);
             if (found) _.extend(found, request.payload);
             _.delay(function () {
                 reply(found).code(found ? 200 : 404);
-            }, self.delay);
+            }, options.delay);
         }
     });
 
     next();
 };
 
-module.exports = API;
+// multiple=true allows the plugin to be registered more than once
+// the pkg attribute will make the plugin name/version match package.json
+exports.register.attributes = {
+    multiple: true,
+    pkg: require("./package.json")
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "url": "git://github.com/henrikjoreteg/hapi-dummy-api"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/lab/bin/lab -c -v"
+  },
+  "devDependencies": {
+    "hapi": "^6.4.0",
+    "lab": "^4.0.1"
   }
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,0 +1,213 @@
+var Lab = require('lab'),
+    Hapi = require('hapi');
+
+var lab = exports.lab = Lab.script();
+var pseudoAPI = require('../');
+
+
+lab.experiment('hapi-dummy-api', function () {
+    var server = new Hapi.Server();
+
+    var opts = {
+        data: [{
+            id: 0,
+            name: 'chair'
+        }, {
+            id: "one",
+            name: 'table'
+        }],
+        rootUrl: '/api/things'
+    };
+
+    var root = opts.rootUrl;
+
+    lab.test('Plugin successfully loads', function (done) {
+
+        server.pack.register({
+            plugin: pseudoAPI,
+            options: opts
+        }, function (err) {
+            Lab.expect(err).to.equal(undefined);
+            done();
+        });
+    });
+
+    lab.test('Plugin registers routes', function (done) {
+        var table = server.table();
+        Lab.expect(table).to.have.length(5);
+
+        Lab.expect(table[0].path).to.equal(root);
+        Lab.expect(table[0].method).to.equal('get');
+
+        Lab.expect(table[1].path).to.equal(root + '/{id}');
+        Lab.expect(table[1].method).to.equal('get');
+
+        Lab.expect(table[2].path).to.equal(root);
+        Lab.expect(table[2].method).to.equal('post');
+
+        Lab.expect(table[3].path).to.equal(root + '/{id}');
+        Lab.expect(table[3].method).to.equal('delete');
+
+        Lab.expect(table[4].path).to.equal(root + '/{id}');
+        Lab.expect(table[4].method).to.equal('put');
+
+        done();
+    });
+
+    lab.test('get a thing', function (done) {
+        var options = {
+            method: "GET",
+            url: root + '/0'
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(200);
+            Lab.expect(result).to.be.an('object');
+            Lab.expect(result.name).to.equal(opts.data[0].name);
+            Lab.expect(result.id).to.equal(opts.data[0].id);
+            done();
+        });
+    });
+
+    lab.test('get a thing that has a string for an id', function (done) {
+        var options = {
+            method: "GET",
+            url: root + '/one'
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(200);
+            Lab.expect(result).to.be.an('object');
+            Lab.expect(result.name).to.equal(opts.data[1].name);
+            Lab.expect(result.id).to.equal(opts.data[1].id);
+            done();
+        });
+    });
+
+    lab.test('get all the things', function (done) {
+        var options = {
+            method: "GET",
+            url: root
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(200);
+            Lab.expect(result).to.be.an('array');
+            Lab.expect(result.length).to.equal(opts.data.length);
+            done();
+        });
+    });
+
+
+    lab.test('get a thing that does not exist', function (done) {
+        var options = {
+            method: "GET",
+            url: root + '/zzz'
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(404);
+            done();
+        });
+    });
+
+    lab.test('post a thing', function (done) {
+        var options = {
+            method: "POST",
+            url: root,
+            payload: {
+                name: "cup"
+            }
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(201);
+            Lab.expect(result).to.be.an('object');
+            Lab.expect(result.id).to.equal(opts.data[2].id);
+            Lab.expect(result.name).to.equal("cup");
+            done();
+        });
+    });
+
+    lab.test('delete a thing', function (done) {
+        var options = {
+            method: "DELETE",
+            url: root + "/2"
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(200);
+            Lab.expect(result).to.be.an('object');
+            Lab.expect(result.id).to.equal(opts.data[2].id);
+            Lab.expect(result.name).to.equal(opts.data[2].name);
+            done();
+        });
+    });
+
+    lab.test('delete a thing that does not exist', function (done) {
+        var options = {
+            method: "DELETE",
+            url: root + "/37337"
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(404);
+            Lab.expect(result).to.equal(null);
+            done();
+        });
+    });
+
+    lab.test('update a thing', function (done) {
+        var options = {
+            method: "PUT",
+            url: root + "/one",
+            payload: {
+                name: "rock"
+            }
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(200);
+            Lab.expect(result).to.be.an('object');
+            Lab.expect(result.id).to.equal(opts.data[1].id);
+            Lab.expect(result.name).to.equal("rock");
+            done();
+        });
+    });
+
+    lab.test('update a thing that does not exist', function (done) {
+        var options = {
+            method: "PUT",
+            url: root + "/9999",
+            payload: {
+                name: "rock"
+            }
+        };
+
+        server.inject(options, function (response) {
+            var result = response.result;
+
+            Lab.expect(response.statusCode).to.equal(404);
+            Lab.expect(result).to.equal(null);
+            done();
+        });
+    });
+
+
+});


### PR DESCRIPTION
First of all, thanks for this and for AmpersandJS :)

This PR makes this module conform a bit more to hapi plugin conventions. instead if dynamically creating plugins via a constructor, it instead leverages the `options` argument when registering the plugin to pass in the dummy data/config object. It also specifies `multiple: true` in the plugin attributes to allow the plugin to be registered multiple times.

I realize that this PR touches 60% of the code, and I understand that it fundamentally changes the way the dummy APIs are created and registered. If this proposed convention does not suit your tastes, feel free to reject this PR... no hard feelings, I can always fork :)
